### PR TITLE
✨ Feature: 약관 조회 및 동의 API 구현

### DIFF
--- a/src/main/java/com/campusmarket/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/campusmarket/backend/domain/member/entity/Member.java
@@ -180,4 +180,8 @@ public class Member {
         this.termsCompleted = true;
     }
 
+    public void updateTermsCompleted(Boolean termsCompleted){
+        this.termsCompleted = termsCompleted;
+    }
+
 }

--- a/src/main/java/com/campusmarket/backend/domain/terms/constant/TermCode.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/constant/TermCode.java
@@ -1,0 +1,6 @@
+package com.campusmarket.backend.domain.terms.constant;
+
+public enum TermCode {
+    SERVICE_USE,
+    PRIVACY_COLLECTION
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/constant/TermsErrorCode.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/constant/TermsErrorCode.java
@@ -1,0 +1,19 @@
+package com.campusmarket.backend.domain.terms.constant;
+
+import com.campusmarket.backend.global.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermsErrorCode implements BaseErrorCode {
+
+    TERM_AGREEMENTS_EMPTY("TERMS_001", "약관 동의 요청이 비어 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TERM_CODE("TERMS_002", "유효하지 않은 약관 코드입니다.", HttpStatus.BAD_REQUEST),
+    REQUIRED_TERM_NOT_AGREED("TERMS_003", "필수 약관에 동의해야 합니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/controller/TermsController.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/controller/TermsController.java
@@ -1,0 +1,42 @@
+package com.campusmarket.backend.domain.terms.controller;
+
+import com.campusmarket.backend.domain.terms.dto.request.TermsAgreementCreateReqDto;
+import com.campusmarket.backend.domain.terms.dto.response.MyTermsAgreementResDto;
+import com.campusmarket.backend.domain.terms.dto.response.TermsAgreementSaveResDto;
+import com.campusmarket.backend.domain.terms.dto.response.TermsListResDto;
+import com.campusmarket.backend.domain.terms.service.TermsService;
+import com.campusmarket.backend.global.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/terms")
+public class TermsController implements TermsControllerDocs {
+
+    private final TermsService termsService;
+
+    @Override
+    @GetMapping
+    public ApiResponse<TermsListResDto> getTerms() {
+        return ApiResponse.success(termsService.getTerms());
+    }
+
+    @Override
+    @PostMapping("/agreements")
+    public ApiResponse<TermsAgreementSaveResDto> saveAgreements(
+            @RequestHeader("guestUuid") String guestUuid,
+            @Valid @RequestBody TermsAgreementCreateReqDto reqDto
+    ) {
+        return ApiResponse.success(termsService.saveAgreements(guestUuid, reqDto));
+    }
+
+    @Override
+    @GetMapping("/agreements/me")
+    public ApiResponse<MyTermsAgreementResDto> getMyAgreements(
+            @RequestHeader("guestUuid") String guestUuid
+    ) {
+        return ApiResponse.success(termsService.getMyAgreements(guestUuid));
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/controller/TermsControllerDocs.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/controller/TermsControllerDocs.java
@@ -1,0 +1,32 @@
+package com.campusmarket.backend.domain.terms.controller;
+
+import com.campusmarket.backend.domain.terms.dto.request.TermsAgreementCreateReqDto;
+import com.campusmarket.backend.domain.terms.dto.response.MyTermsAgreementResDto;
+import com.campusmarket.backend.domain.terms.dto.response.TermsAgreementSaveResDto;
+import com.campusmarket.backend.domain.terms.dto.response.TermsListResDto;
+import com.campusmarket.backend.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestHeader;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Terms", description = "약관 API")
+public interface TermsControllerDocs {
+    @Operation(summary = "이용 약관 조회", description = "이벤트용 약관 목록을 조회합니다.")
+    ApiResponse<TermsListResDto> getTerms();
+
+    @Operation(summary = "약관 동의 저장", description = "현재 회원의 약관 동의 여부를 저장합니다.")
+    ApiResponse<TermsAgreementSaveResDto> saveAgreements(
+            @Parameter(description = "게스트 UUID", required = true)
+            @RequestHeader("guestUuid") String guestUuid,
+            @Valid @RequestBody TermsAgreementCreateReqDto reqDto
+    );
+
+    @Operation(summary = "내 약관 동의 내역 조회", description = "현재 회원의 약관 동의 상태를 조회합니다.")
+    ApiResponse<MyTermsAgreementResDto> getMyAgreements(
+            @Parameter(description = "게스트 UUID", required = true)
+            @RequestHeader("guestUuid") String guestUuid
+    );
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/request/TermAgreementItemReqDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/request/TermAgreementItemReqDto.java
@@ -1,0 +1,10 @@
+package com.campusmarket.backend.domain.terms.dto.request;
+
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+
+// 약관 동의 요청 항목
+public record TermAgreementItemReqDto(
+        TermCode termCode,
+        Boolean agreed
+) {
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/request/TermsAgreementCreateReqDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/request/TermsAgreementCreateReqDto.java
@@ -1,0 +1,9 @@
+package com.campusmarket.backend.domain.terms.dto.request;
+
+import java.util.List;
+
+// 약관 동의 저장 요청
+public record TermsAgreementCreateReqDto(
+        List<TermAgreementItemReqDto> agreements
+) {
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/response/MyTermAgreementItemResDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/response/MyTermAgreementItemResDto.java
@@ -1,0 +1,30 @@
+package com.campusmarket.backend.domain.terms.dto.response;
+
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+
+import java.time.LocalDateTime;
+
+// 내 약관 동의 항목
+public record MyTermAgreementItemResDto(
+        TermCode termCode,
+        String title,
+        Boolean required,
+        Boolean agreed,
+        LocalDateTime agreedAt
+) {
+    public static MyTermAgreementItemResDto of(
+            TermCode termCode,
+            String title,
+            Boolean required,
+            Boolean agreed,
+            LocalDateTime agreedAt
+    ) {
+        return new MyTermAgreementItemResDto(
+                termCode,
+                title,
+                required,
+                agreed,
+                agreedAt
+        );
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/response/MyTermsAgreementResDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/response/MyTermsAgreementResDto.java
@@ -1,0 +1,12 @@
+package com.campusmarket.backend.domain.terms.dto.response;
+
+import java.util.List;
+
+// 내 약관 동의 내역
+public record MyTermsAgreementResDto(
+        List<MyTermAgreementItemResDto> agreements
+) {
+    public static MyTermsAgreementResDto of(List<MyTermAgreementItemResDto> agreements) {
+        return new MyTermsAgreementResDto(agreements);
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermItemResDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermItemResDto.java
@@ -1,0 +1,20 @@
+package com.campusmarket.backend.domain.terms.dto.response;
+
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+
+// 약관 목록 항목
+public record TermItemResDto(
+        TermCode termCode,
+        String title,
+        String content,
+        Boolean required
+) {
+    public static TermItemResDto of(
+            TermCode termCode,
+            String title,
+            String content,
+            Boolean required
+    ){
+        return new TermItemResDto(termCode, title, content, required);
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermsAgreementSaveResDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermsAgreementSaveResDto.java
@@ -1,0 +1,10 @@
+package com.campusmarket.backend.domain.terms.dto.response;
+
+// 약관 동의 저장 응답
+public record TermsAgreementSaveResDto(
+        Boolean termsCompleted
+) {
+    public static TermsAgreementSaveResDto of(Boolean termsCompleted) {
+        return new TermsAgreementSaveResDto(termsCompleted);
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermsListResDto.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/dto/response/TermsListResDto.java
@@ -1,0 +1,12 @@
+package com.campusmarket.backend.domain.terms.dto.response;
+
+import java.util.List;
+
+// 약관 목록 응답
+public record TermsListResDto(
+        List<TermItemResDto> terms
+) {
+    public static TermsListResDto of(List<TermItemResDto> terms){
+        return new TermsListResDto(terms);
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/entity/MemberTermAgreement.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/entity/MemberTermAgreement.java
@@ -1,0 +1,90 @@
+package com.campusmarket.backend.domain.terms.entity;
+
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+import com.campusmarket.backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "회원약관동의")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTermAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "회원약관동의PK")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "회원PK", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "약관코드", nullable = false, length = 50)
+    private TermCode termCode;
+
+    @Column(name = "약관제목", nullable = false, length = 100)
+    private String termTitle;
+
+    @Column(name = "필수여부", nullable = false)
+    private Boolean required;
+
+    @Column(name = "동의여부", nullable = false)
+    private Boolean agreed;
+
+    @Column(name = "동의일시")
+    private LocalDateTime agreedAt;
+
+    @Column(name = "생성일")
+    private LocalDateTime createdAt;
+
+    @Column(name = "수정일")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private MemberTermAgreement(
+            Member member,
+            TermCode termCode,
+            String termTitle,
+            Boolean required,
+            Boolean agreed
+    ) {
+        this.member = member;
+        this.termCode = termCode;
+        this.termTitle = termTitle;
+        this.required = required;
+        this.agreed = agreed;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (Boolean.TRUE.equals(this.agreed)) {
+            this.agreedAt = now;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateAgreement(Boolean agreed) {
+        this.agreed = agreed;
+
+        if (Boolean.TRUE.equals(agreed)) {
+            this.agreedAt = LocalDateTime.now();
+        } else {
+            this.agreedAt = null;
+        }
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/exception/TermsException.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/exception/TermsException.java
@@ -1,0 +1,14 @@
+package com.campusmarket.backend.domain.terms.exception;
+
+import com.campusmarket.backend.global.exception.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TermsException extends RuntimeException{
+    private final BaseErrorCode errorCode;
+
+    public TermsException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/repository/MemberTermAgreementRepository.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/repository/MemberTermAgreementRepository.java
@@ -1,0 +1,16 @@
+package com.campusmarket.backend.domain.terms.repository;
+
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+import com.campusmarket.backend.domain.terms.entity.MemberTermAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberTermAgreementRepository extends JpaRepository<MemberTermAgreement, Long> {
+
+    List<MemberTermAgreement> findByMemberId(Long memberId);
+
+    Optional<MemberTermAgreement> findByMemberIdAndTermCode(Long memberId, TermCode termCode);
+
+}

--- a/src/main/java/com/campusmarket/backend/domain/terms/service/TermsService.java
+++ b/src/main/java/com/campusmarket/backend/domain/terms/service/TermsService.java
@@ -1,0 +1,134 @@
+package com.campusmarket.backend.domain.terms.service;
+
+import com.campusmarket.backend.domain.member.constant.MemberErrorCode;
+import com.campusmarket.backend.domain.member.entity.Member;
+import com.campusmarket.backend.domain.member.exception.MemberException;
+import com.campusmarket.backend.domain.member.repository.MemberRepository;
+import com.campusmarket.backend.domain.terms.constant.TermCode;
+import com.campusmarket.backend.domain.terms.constant.TermsErrorCode;
+import com.campusmarket.backend.domain.terms.dto.request.TermAgreementItemReqDto;
+import com.campusmarket.backend.domain.terms.dto.request.TermsAgreementCreateReqDto;
+import com.campusmarket.backend.domain.terms.dto.response.*;
+import com.campusmarket.backend.domain.terms.entity.MemberTermAgreement;
+import com.campusmarket.backend.domain.terms.exception.TermsException;
+import com.campusmarket.backend.domain.terms.repository.MemberTermAgreementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TermsService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTermAgreementRepository memberTermAgreementRepository;
+
+    private List<TermItemResDto> getFixedTerms() {
+        return List.of(
+                TermItemResDto.of(
+                        TermCode.SERVICE_USE,
+                        "이용약관 동의",
+                        "캠퍼스 중고마켓 이벤트 참여를 위한 이용약관입니다.",
+                        true
+                ),
+                TermItemResDto.of(
+                        TermCode.PRIVACY_COLLECTION,
+                        "개인정보 수집 및 이용 동의",
+                        "이벤트 참여를 위한 개인정보 수집 및 이용 동의 약관입니다.",
+                        true
+                )
+        );
+    }
+
+    public TermsListResDto getTerms(){
+        return TermsListResDto.of(getFixedTerms());
+    }
+
+    @Transactional
+    public TermsAgreementSaveResDto saveAgreements(String guestUuid, TermsAgreementCreateReqDto reqDto) {
+        Member member = findMemberByGuestUuid(guestUuid);
+
+        if (reqDto.agreements() == null || reqDto.agreements().isEmpty()) {
+            throw new TermsException(TermsErrorCode.TERM_AGREEMENTS_EMPTY);
+        }
+
+        Map<TermCode, TermItemResDto> termMap = getFixedTerms().stream()
+                .collect(Collectors.toMap(TermItemResDto::termCode, term -> term));
+
+        for (TermAgreementItemReqDto item : reqDto.agreements()) {
+            if (item.termCode() == null || !termMap.containsKey(item.termCode())) {
+                throw new TermsException(TermsErrorCode.INVALID_TERM_CODE);
+            }
+
+            TermItemResDto fixedTerm = termMap.get(item.termCode());
+
+            MemberTermAgreement agreement = memberTermAgreementRepository
+                    .findByMemberIdAndTermCode(member.getId(), item.termCode())
+                    .orElseGet(() -> MemberTermAgreement.builder()
+                            .member(member)
+                            .termCode(item.termCode())
+                            .termTitle(fixedTerm.title())
+                            .required(fixedTerm.required())
+                            .agreed(Boolean.FALSE)
+                            .build());
+
+            agreement.updateAgreement(Boolean.TRUE.equals(item.agreed()));
+            memberTermAgreementRepository.save(agreement);
+        }
+
+        boolean termsCompleted = isAllRequiredTermsAgreed(member.getId(), termMap);
+        member.updateTermsCompleted(termsCompleted);
+
+        return TermsAgreementSaveResDto.of(termsCompleted);
+    }
+
+    public MyTermsAgreementResDto getMyAgreements(String guestUuid) {
+        Member member = findMemberByGuestUuid(guestUuid);
+
+        Map<TermCode, MemberTermAgreement> savedAgreementMap = memberTermAgreementRepository.findByMemberId(member.getId())
+                .stream()
+                .collect(Collectors.toMap(MemberTermAgreement::getTermCode, agreement -> agreement));
+
+        List<MyTermAgreementItemResDto> results = getFixedTerms().stream()
+                .map(term -> {
+                    MemberTermAgreement saved = savedAgreementMap.get(term.termCode());
+
+                    return MyTermAgreementItemResDto.of(
+                            term.termCode(),
+                            term.title(),
+                            term.required(),
+                            saved != null && Boolean.TRUE.equals(saved.getAgreed()),
+                            saved != null ? saved.getAgreedAt() : null
+                    );
+                })
+                .toList();
+
+        return MyTermsAgreementResDto.of(results);
+    }
+
+    private Member findMemberByGuestUuid(String guestUuid) {
+        return memberRepository.findByGuestUuid(guestUuid)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private boolean isAllRequiredTermsAgreed(Long memberId, Map<TermCode, TermItemResDto> termMap) {
+        for (TermItemResDto term : termMap.values()) {
+            if (Boolean.TRUE.equals(term.required())) {
+                MemberTermAgreement agreement = memberTermAgreementRepository
+                        .findByMemberIdAndTermCode(memberId, term.termCode())
+                        .orElse(null);
+
+                if (agreement == null || !Boolean.TRUE.equals(agreement.getAgreed())) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## ✨ Feature: 약관 조회 및 동의 API 구현

### 📌 구현 내용
- GET /api/terms 약관 목록 조회 API 구현
- POST /api/terms/agreements 약관 동의 저장 API 구현
- GET /api/terms/agreements/me 내 약관 동의 내역 조회 API 구현

### 📌 주요 로직
- 이벤트 참여용 필수 약관 2종을 고정 응답으로 제공
  - 이용약관 동의
  - 개인정보 수집 및 이용 동의
- 현재 회원의 약관 동의 여부를 회원약관동의 테이블에 저장
- 필수 약관이 모두 동의된 경우 Member의 termsCompleted 값을 true로 반영

### 📌 테스트
- 약관 목록 조회 정상 동작 확인
- 약관 동의 저장 후 termsCompleted=true 반영 확인
- 내 약관 동의 내역 조회 정상 동작 확인

<img width="740" height="747" alt="스크린샷 2026-03-24 214237" src="https://github.com/user-attachments/assets/97615e2d-32f6-4b79-9a84-742e5343671b" />

<img width="786" height="878" alt="스크린샷 2026-03-24 214322" src="https://github.com/user-attachments/assets/a5760e2b-e6de-404a-8035-34b9257445b4" />

<img width="778" height="897" alt="스크린샷 2026-03-24 214603" src="https://github.com/user-attachments/assets/e9970fe9-b579-4498-b321-b601813ede8e" />

### 📌 추가 사항
- MemberTermAgreement 엔티티 및 Repository 추가
- TermsControllerDocs / TermsController / TermsService 구현
- 약관 관련 요청/응답 DTO 추가